### PR TITLE
Fix flipboard: Shanghai label, header title size, status column width

### DIFF
--- a/script.js
+++ b/script.js
@@ -202,7 +202,7 @@ function initFlipBoard() {
             {
                 flight: "MU103",
                 time: "2011",
-                destination: "SHANGHAI CHINA",
+                destination: "SHANGHAI",
                 gate: "PVG",
                 status: "MIDDLE SCHOOL"
             },

--- a/style.css
+++ b/style.css
@@ -302,8 +302,8 @@ body {
 }
 
 .header-title {
-    font-size: 0.7em;
-    color: var(--text-muted);
+    font-size: 1em;
+    color: var(--text-secondary);
     letter-spacing: 5px;
     text-transform: uppercase;
     line-height: 1.8;
@@ -354,9 +354,9 @@ body {
 
 .row .flight,      .column-titles .flight      { width: 12%; }
 .row .time,        .column-titles .time        { width: 12%; }
-.row .destination, .column-titles .destination { width: 35%; }
+.row .destination, .column-titles .destination { width: 30%; }
 .row .gate,        .column-titles .gate        { width: 15%; }
-.row .status,      .column-titles .status      { width: 26%; }
+.row .status,      .column-titles .status      { width: 31%; }
 
 .destination > span {
     font-size: 1.2em;


### PR DESCRIPTION
- script.js: changed destination from "SHANGHAI CHINA" to "SHANGHAI" (was missed previously; index.html change only affected experience card)
- style.css: increased .header-title font-size from 0.7em to 1em and lightened color to text-secondary so "Flight Instructor / YOON HYUK UHR" is more visible
- style.css: redistributed column widths (destination 35→30%, status 26→31%) so "MIDDLE SCHOOL" no longer wraps

https://claude.ai/code/session_01Gg4Am8DBGdqkRfD12Ta6qL